### PR TITLE
chore: Pin Github Actions to Commit Hashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         ruby:
           - '3.0'
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@ca041f971d66735f3e5ff1e21cc13e2d51e7e535 # v1.233.0
       with:

--- a/.github/workflows/release-gem.yml
+++ b/.github/workflows/release-gem.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Set up Ruby 3.X
       uses: ruby/setup-ruby@ca041f971d66735f3e5ff1e21cc13e2d51e7e535 # v1.233.0
       with:
@@ -39,7 +39,7 @@ jobs:
     name: Publish
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Publish to RubyGems
       if: needs.build.result == 'success' || github.event.inputs.force_release == true
       run: |

--- a/.github/workflows/rule_specs.yml
+++ b/.github/workflows/rule_specs.yml
@@ -6,6 +6,6 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Ensure Each Rule has a Spec
         run: ls $(for spec in $(ls lib/claws/rule/ | sed 's/\.rb/_spec\.rb/g'); do echo spec/claws/rule/$spec; done) >/dev/null


### PR DESCRIPTION
This PR includes automated changes from running [frizbee](https://github.com/stacklok/frizbee) to pin Github Actions. For more information on what this actually means, take a look at [our documentation on UnpinnedActions](https://github.com/betterment/claws?tab=readme-ov-file#unpinnedactions). Because `frizbee` will be replacing tags with their corresponding commit hash, this change should fundamentally be a no-op. This change just makes our code more explicit about what we're using.

Note that because we're touching Github Workflow files in this PR, there is a chance that [Claws](https://github.com/betterment/claws), our GHA Static Analyzer, will find other issues in those files that were introduced before this PR was created. These findings will need to be addressed before this PR can be merged. 

The Claws documentation has a good list for how to remediate each type of finding, but for brevity, here are some of the commonly seen ones:

* RiskyTriggers: Fires when a workflow has workflow_dispatch or pull_request_target; remediate by leaving comments explaning why, and put an ignore statement ([example](https://github.com/Betterment/retail/blob/92e76923f4e5d51e8386301538e383883cd5eb57/.github/workflows/create_datadog_slo.yml#L2-L4))
* UnsafeCheckout: Fires when a workflow checks out user supplied code; remediate by leaving a comment explaining how the user supplied code is used and confirm it isn't executed ([example](https://github.com/Betterment/linda-test/blob/6cd5954c7c1d2bdb781239b6686b3a5dcbcd6fda/.github/workflows/claws_fork_friendly.yml#L50-L54))

For other findings and how to remediate them, check the [Claws docs!](https://github.com/betterment/claws?tab=readme-ov-file#built-in-rules)

