### PR TITLE
Use `analyze` as the name for the script

### DIFF
--- a/bin/analyze
+++ b/bin/analyze
@@ -5,7 +5,7 @@ require "claws"
 require "slop"
 
 flags = Slop::Options.new
-flags.banner =  "usage: process [options] ..."
+flags.banner =  "usage: analyze [options] ..."
 flags.separator ""
 flags.separator "Options:"
 flags.string "-c", "--config", required: true


### PR DESCRIPTION
Wasn't sure what `process` is referring to? Perhaps it was the old name of the script? Anyways, let's use `analyze` since that's the current script name.

We could also be more dynamic and get the filename of the script instead of hardcoding it.