### PR TITLE
fix(CommandInjection): only throw on usages of github.event.|inputs

### DIFF
--- a/lib/claws/rule/command_injection.rb
+++ b/lib/claws/rule/command_injection.rb
@@ -8,7 +8,7 @@ module Claws
         https://github.com/betterment/claws/blob/main/README.md#commandinjection
       DESC
 
-      on_step '$step.run =~ ".*{{.*(github.event|inputs)\..*}}.*"', highlight: "run"
+      on_step '$step.run =~ ".*{{.*(github\.event|inputs)\..*}}.*"', highlight: "run"
     end
   end
 end

--- a/lib/claws/rule/command_injection.rb
+++ b/lib/claws/rule/command_injection.rb
@@ -8,7 +8,7 @@ module Claws
         https://github.com/betterment/claws/blob/main/README.md#commandinjection
       DESC
 
-      on_step '$step.run =~ ".*{{[ ]+.*(github.event.inputs|inputs).*}}.*"', highlight: "run"
+      on_step '$step.run =~ ".*{{[ ]+.*(github.event\.|inputs).*}}.*"', highlight: "run"
     end
   end
 end

--- a/lib/claws/rule/command_injection.rb
+++ b/lib/claws/rule/command_injection.rb
@@ -8,7 +8,7 @@ module Claws
         https://github.com/betterment/claws/blob/main/README.md#commandinjection
       DESC
 
-      on_step '$step.run =~ ".*{{[ ]+.*(github.event|inputs).*}}.*"', highlight: "run"
+      on_step '$step.run =~ ".*{{[ ]+.*(github.event.inputs|inputs).*}}.*"', highlight: "run"
     end
   end
 end

--- a/lib/claws/rule/command_injection.rb
+++ b/lib/claws/rule/command_injection.rb
@@ -8,7 +8,7 @@ module Claws
         https://github.com/betterment/claws/blob/main/README.md#commandinjection
       DESC
 
-      on_step '$step.run =~ ".*{{[ ]+.*(github.event\.|inputs).*}}.*"', highlight: "run"
+      on_step '$step.run =~ ".*{{.*(github.event|inputs)\..*}}.*"', highlight: "run"
     end
   end
 end

--- a/spec/claws/rule/command_injection_spec.rb
+++ b/spec/claws/rule/command_injection_spec.rb
@@ -32,10 +32,14 @@ RSpec.describe Claws::Rule::CommandInjection do
 
     it "flags a step with github expression without spaces" do
       violations = analyze(<<~YAML)
-        name: Pull Request Number
+        name: Greeting
 
         on:
-          pull_request:
+          workflow_dispatch:
+            inputs:
+              name:
+                description: 'Who I should say hello to?'
+                required: true
 
         jobs:
           greet:
@@ -43,9 +47,8 @@ RSpec.describe Claws::Rule::CommandInjection do
             steps:
               - name: Checkout
                 uses: actions/checkout@v1
-              - name: Show PR Number
-                # This expression does not contain a space between the enclosing brace and its contents
-                run: echo "PR number is ${{github.event.pull_request.number}}"
+              - name: Greet
+                run: ./scripts/greet.sh "${{join(github.event.inputs.name)}}"
       YAML
 
       expect(violations.count).to eq(1)

--- a/spec/claws/rule/command_injection_spec.rb
+++ b/spec/claws/rule/command_injection_spec.rb
@@ -55,5 +55,29 @@ RSpec.describe Claws::Rule::CommandInjection do
 
       expect(violations.count).to eq(0)
     end
+
+    it "doesn't flag non-inputs usages of github.event" do
+      violations = analyze(<<~YAML)
+        name: Greeting
+
+        on:
+          workflow_dispatch:
+            inputs:
+              name:
+                description: 'Who I should say hello to?'
+                required: true
+
+        jobs:
+          greet:
+            runs-on: ubuntu-latest
+            steps:
+              - name: Checkout
+                uses: actions/checkout@v1
+              - name: Greet
+                run: ./scripts/greet.sh "${{ github.event_name }}"
+      YAML
+
+      expect(violations.count).to eq(0)
+    end
   end
 end

--- a/spec/claws/rule/command_injection_spec.rb
+++ b/spec/claws/rule/command_injection_spec.rb
@@ -30,6 +30,27 @@ RSpec.describe Claws::Rule::CommandInjection do
       expect(violations[0].name).to eq("CommandInjection")
     end
 
+    it "flags a step with github expression without spaces" do
+      violations = analyze(<<~YAML)
+        name: Pull Request Number
+
+        on:
+          pull_request:
+
+        jobs:
+          greet:
+            runs-on: ubuntu-latest
+            steps:
+              - name: Checkout
+                uses: actions/checkout@v1
+              - name: Show PR Number
+                # This expression does not contain a space between the enclosing brace and its contents
+                run: echo "PR number is ${{github.event.pull_request.number}}"
+      YAML
+
+      expect(violations.count).to eq(1)
+    end
+
     it "doesn't flag a step if it executes a command safely" do
       violations = analyze(<<~YAML)
         name: Greeting


### PR DESCRIPTION
I ran into a case where a PR was failing `claws` due to using `github.event_name` which should be entirely safe. I down-scoped the `CommandInjection` rule to only violate on `run` usages of  `github.event\.` (newly modified regex) and `inputs` (existing regex) and added a spec to ensure non-inputs checks don't violate.

**Note:** This would still cause violations on things like `github.event.pull_request.number` which aren't user-generated and should be safe, but since it's impossible(?) to enumerate all of the non-free-form/user-generated fields on the event object, this change at least gives us things like `github.event_name`. Also, you can still use `env` as a way to safely use these properties.