### PR TITLE
chore: bump to 0.9.0 and release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    claws-scan (0.8.0)
+    claws-scan (0.9.0)
       equation (~> 0.6)
       pry
       slop (~> 4.9)

--- a/lib/claws/version.rb
+++ b/lib/claws/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Claws
-  VERSION = "0.8.0"
+  VERSION = "0.9.0"
 end


### PR DESCRIPTION
We've had a couple bug fixes and improvements land on main in the last couple of weeks but haven't pushed out a new release. This will take care of that. We should not merge this until https://github.com/Betterment/claws/pull/7 is ready.