### PR TITLE
fix: bump version of ruby used for release

### DIFF
--- a/.github/workflows/release-gem.yml
+++ b/.github/workflows/release-gem.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Ruby 3.X
       uses: ruby/setup-ruby@ca041f971d66735f3e5ff1e21cc13e2d51e7e535 # v1.233.0
       with:
-        ruby-version: '3.0'
+        ruby-version: '3.2.3'
         bundler-cache: true
     - name: Run the default task
       run: bundle exec rake


### PR DESCRIPTION
The release job failed because it was using a version of Ruby that the gem considered out of date. This fixes that