### PR TITLE
fix: use find instead of first when locating YAML keys with line numbers

### DIFF
--- a/lib/claws/workflow.rb
+++ b/lib/claws/workflow.rb
@@ -123,7 +123,7 @@ class Workflow
 
   def extract_normalized_on(workflow)
     if workflow["on"].is_a? String
-      line_number = workflow.keys.first { |k| k == "on" }.line
+      line_number = workflow.keys.find { |k| k == "on" }.line
       @on = workflow["on"] = [workflow["on"]]
       set_attr_line_number(:@on, line_number)
     else
@@ -211,7 +211,7 @@ class Workflow
   end
 
   def copy_key_with_line(blob, src, dst)
-    line = blob.keys.first { |k| k.to_sym == src.to_sym }.line
+    line = blob.keys.find { |k| k.to_sym == src.to_sym }.line
 
     new_key = String.new(dst).tap { |x| x.instance_eval { |_x| define_singleton_method(:line, -> { line }) } }
     # freezing it keeps ruby from making a copy w/o `line`

--- a/spec/claws/workflow_spec.rb
+++ b/spec/claws/workflow_spec.rb
@@ -48,30 +48,6 @@ RSpec.describe Workflow do
 
       expect(workflow.meta["triggers"]).to eq(["pull_request"])
     end
-
-    context "key normalization" do
-      it "preserves line numbers when normalizing hyphenated keys that are not the first key" do
-        workflow = described_class.load(<<~YAML)
-          name: test
-
-          on: push
-
-          jobs:
-            build:
-              defaults:
-                run:
-                  working-directory: ./app
-              runs-on: ubuntu-latest
-              steps:
-                - run: echo hello
-        YAML
-
-        job = workflow.jobs["build"]
-        runs_on_key = job.keys.find { |k| k == "runs_on" }
-
-        expect(runs_on_key.line).to eq(10)
-      end
-    end
   end
 
   context "line information" do
@@ -100,6 +76,30 @@ RSpec.describe Workflow do
       expect(BaseRule.parse_rule("$step.with.type_integer == 1").eval_with(values:)).to eq true
       expect(BaseRule.parse_rule("$step.with.type_nil == nil").eval_with(values:)).to eq true
       expect(BaseRule.parse_rule("$step.with.type_float == 1.2").eval_with(values:)).to eq true
+    end
+
+    context "key normalization" do
+      it "preserves line numbers when normalizing hyphenated keys that are not the first key" do
+        workflow = described_class.load(<<~YAML)
+          name: test
+
+          on: push
+
+          jobs:
+            build:
+              defaults:
+                run:
+                  working-directory: ./app
+              runs-on: ubuntu-latest
+              steps:
+                - run: echo hello
+        YAML
+
+        job = workflow.jobs["build"]
+        runs_on_key = job.keys.find { |k| k == "runs_on" }
+
+        expect(runs_on_key.line).to eq(10)
+      end
     end
   end
 

--- a/spec/claws/workflow_spec.rb
+++ b/spec/claws/workflow_spec.rb
@@ -48,6 +48,30 @@ RSpec.describe Workflow do
 
       expect(workflow.meta["triggers"]).to eq(["pull_request"])
     end
+
+    context "key normalization" do
+      it "preserves line numbers when normalizing hyphenated keys that are not the first key" do
+        workflow = described_class.load(<<~YAML)
+          name: test
+
+          on: push
+
+          jobs:
+            build:
+              defaults:
+                run:
+                  working-directory: ./app
+              runs-on: ubuntu-latest
+              steps:
+                - run: echo hello
+        YAML
+
+        job = workflow.jobs["build"]
+        runs_on_key = job.keys.find { |k| k == "runs_on" }
+
+        expect(runs_on_key.line).to eq(10)
+      end
+    end
   end
 
   context "line information" do


### PR DESCRIPTION
**Summary**

Fix incorrect line number reporting for lint violations when YAML keys with hyphens (e.g., runs-on) are normalized to underscores (runs_on)

The bug caused violations to be reported on the first key in a hash instead of the actual offending key

**Test plan**
 Added spec to verify line numbers are preserved when normalizing hyphenated keys that are not first in the hash
 All 59 tests pass