### PR TITLE
Export $workflow.env

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,7 @@ PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/claws/workflow.rb
+++ b/lib/claws/workflow.rb
@@ -4,7 +4,7 @@ require "claws/cli/yaml_with_lines"
 class Workflow
   extend Forwardable
 
-  attr_accessor :data, :on, :jobs, :name, :meta, :permissions
+  attr_accessor :data, :on, :jobs, :name, :meta, :permissions, :env
 
   def_delegators :@workflow, :get_line, :include?, :keys
 
@@ -19,6 +19,7 @@ class Workflow
     extract_normalized_jobs(@workflow)
     extract_normalized_name(@workflow)
     extract_permissions(@workflow)
+    extract_env(@workflow)
 
     @raw_yaml = raw_yaml
   end
@@ -90,6 +91,10 @@ class Workflow
   def extract_permissions(input)
     @permissions = input["permissions"]
     @meta["permissions"] = normalize_permissions(input["permissions"])
+  end
+
+  def extract_env(input)
+    @env = input["env"]
   end
 
   def normalize_permissions(input) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity

--- a/spec/claws/workflow_spec.rb
+++ b/spec/claws/workflow_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Workflow do
       YAML
 
       values = { workflow:, job: workflow.jobs["deploy"], step: workflow.jobs["deploy"]["steps"][0] }
-      expect(BaseRule.parse_rule('$workflow.env.nonexistent == null').eval_with(values:)).to eq true
+      expect(BaseRule.parse_rule("$workflow.env.nonexistent == null").eval_with(values:)).to eq true
     end
   end
 

--- a/spec/claws/workflow_spec.rb
+++ b/spec/claws/workflow_spec.rb
@@ -90,6 +90,24 @@ RSpec.describe Workflow do
       values = { workflow:, job: workflow.jobs["deploy"], step: workflow.jobs["deploy"]["steps"][0] }
       expect(BaseRule.parse_rule("$workflow.env.nonexistent == null").eval_with(values:)).to eq true
     end
+
+    it "returns null if there is no global env block at all" do
+      workflow = described_class.load(<<~YAML)
+        on:
+          pull_request
+
+        jobs:
+          deploy:
+            steps:
+              - id: merge this pull request
+                name: automerge
+                uses: "pascalgn/automerge-action@v0.15.5"
+      YAML
+
+      values = { workflow:, job: workflow.jobs["deploy"], step: workflow.jobs["deploy"]["steps"][0] }
+      expect(BaseRule.parse_rule("$workflow.env == null").eval_with(values:)).to eq true
+      expect(BaseRule.parse_rule("$workflow.env.nonexistent == null").eval_with(values:)).to eq true
+    end
   end
 
   context "line information" do

--- a/spec/claws/workflow_spec.rb
+++ b/spec/claws/workflow_spec.rb
@@ -50,6 +50,48 @@ RSpec.describe Workflow do
     end
   end
 
+  context "global env extraction" do
+    it "returns the contents of the global environment variable by name" do
+      workflow = described_class.load(<<~YAML)
+        on:
+          pull_request
+
+        env:
+          globally_accessible: "very!"
+
+        jobs:
+          deploy:
+            steps:
+              - id: merge this pull request
+                name: automerge
+                uses: "pascalgn/automerge-action@v0.15.5"
+      YAML
+
+      values = { workflow:, job: workflow.jobs["deploy"], step: workflow.jobs["deploy"]["steps"][0] }
+      expect(BaseRule.parse_rule('$workflow.env.globally_accessible == "very!"').eval_with(values:)).to eq true
+    end
+
+    it "returns null if the global environment variable is not defined" do
+      workflow = described_class.load(<<~YAML)
+        on:
+          pull_request
+
+        env:
+          globally_accessible: "very!"
+
+        jobs:
+          deploy:
+            steps:
+              - id: merge this pull request
+                name: automerge
+                uses: "pascalgn/automerge-action@v0.15.5"
+      YAML
+
+      values = { workflow:, job: workflow.jobs["deploy"], step: workflow.jobs["deploy"]["steps"][0] }
+      expect(BaseRule.parse_rule('$workflow.env.nonexistent == null').eval_with(values:)).to eq true
+    end
+  end
+
   context "line information" do
     it "can find the line number of various types" do
       workflow = described_class.load(<<~YAML)


### PR DESCRIPTION
The root keys of a workflow file are manually extracted and exported to the Workflow class before being exposed via the DSL. This means we will occasionally miss stuff that we forgot to export, which in this case is `env`. The plan is to eventually properly parse workflow files with [a schema like this](https://github.com/SchemaStore/schemastore/blob/7c910423df/src/schemas/json/github-workflow.json), but until then, let's export `env` manually to keep on moving. This should help out with #18.